### PR TITLE
Add PrefersNonDefaultGPU desktop entry key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New `cursor.style.blinking` option to set the default blinking state
 - New `cursor.blink_interval` option to configure the blinking frequency
 - Support for cursor blinking escapes (`CSI ? 12 h`, `CSI ? 12 l` and `CSI Ps SP q`)
+- `PrefersNonDefaultGPU` entry to Linux .desktop file
 
 ### Changed
 

--- a/extra/linux/Alacritty.desktop
+++ b/extra/linux/Alacritty.desktop
@@ -5,6 +5,7 @@ Exec=alacritty
 Icon=Alacritty
 Terminal=false
 Categories=System;TerminalEmulator;
+PrefersNonDefaultGPU=true
 
 Name=Alacritty
 GenericName=Terminal


### PR DESCRIPTION
A new Desktop entry key has been added recently (≃ May 2020) to ask for an application to run on a more powerful GPU, if possible.
See: https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html.

A per the doc:
"If true, the application prefers to be run on a more powerful discrete GPU if available, which we describe as “a GPU other than the default one” in this spec to avoid the need to define what a discrete GPU is and in which cases it might be considered more powerful than the default GPU. This key is only a hint and support might not be present depending on the implementation."

Please make sure to document all user-facing changes in the
`CHANGELOG.md` file.

If support for a new escape sequence was added, it should be documented
in `./docs/escape_support.md`.

Since `alacritty_terminal`'s version always tracks the next release, make sure
that the version is bumped according to semver when necessary.

Draft PRs are always welcome, though unless otherwise requested PRs will
not be reviewed until all required and optional CI steps are successful
and they have left the draft stage.
